### PR TITLE
Move create page to express

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,10 +6,10 @@ import { useLoaderData } from "@remix-run/react";
 import { useEffect, useState } from "react";
 import { prismaDatabase } from "~/prismaDatabase";
 
-
+export const expressPort = 4001
 
 export const getSurveys = async () => {
-  const data = await fetch ("http://localhost:4000/",
+  const data = await fetch (`http://localhost:${expressPort}/`,
     
     // {mode: "no-cors"}
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,10 +1,5 @@
-import type { LoaderFunctionArgs, MetaFunction } from "@remix-run/node";
 import { Link, json } from "@remix-run/react";
-import { useLoaderData } from "@remix-run/react";
-
-
 import { useEffect, useState } from "react";
-import { prismaDatabase } from "~/prismaDatabase";
 
 export const expressPort = 4001
 
@@ -26,12 +21,10 @@ export const getSurveys = async () => {
   return surveys
 }
 
-
 type Surveys = {
   name: string;
   id: number;
 }[]
-
 
 function HowManySurveys( { surveysLength } : {surveysLength: number } ) {
   return (

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -33,7 +33,7 @@ type Surveys = {
 }[]
 
 
-function HowManySurveys({ surveysLength }: any ) {
+function HowManySurveys( { surveysLength } : {surveysLength: number } ) {
   return (
     <div>
       <p>The Loader has found {surveysLength} surveys are recorded</p>

--- a/app/routes/create.tsx
+++ b/app/routes/create.tsx
@@ -2,33 +2,35 @@ import { Link } from "@remix-run/react";
 import { expressPort } from "./_index";
 import { useState } from "react";
 
-export const postSurvey = async ({ name }: NewSurvey) => {
-  const response = await fetch (`http://localhost:${expressPort}/insert`, {
+export const postSurvey = async ({ name, question1 }: NewSurvey) => {
+  const response = await fetch(`http://localhost:${expressPort}/insert`, {
     method: "POST",
-    mode: "no-cors",
-    cache: "no-cache",
-    body: JSON.stringify(name)
-    }
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ "name": name })
+  }
   )
-// full "response" is a massive sprawling object, .json() gives us the most salient part of it somehow
-const responseJson = await response.json()
-console.log("postSurvey function called. Response received was:", response)
+  // full "response" is a massive sprawling object, .json() gives us the most salient part of it somehow
+  const responseJson = await response.json()
+  console.log("postSurvey function called. Response received was:", response)
 }
 
 type NewSurvey = {
   name: string;
+  question1?: string;
 }
 
-export default function CreateSurveyForm () {
+export default function CreateSurveyForm() {
   const [submittedValue, setSubmittedValue] = useState("")
   console.log("submittedValue is:", submittedValue)
   return (
     <div>
-      <input type="text" value = {submittedValue} onChange={(e) => {setSubmittedValue(e.target.value)}}/>
+      <input type="text" value={submittedValue} onChange={(e) => { setSubmittedValue(e.target.value) }} />
       <button type="submit" onClick={
-        ()=>{
+        () => {
           console.log("Submit button has been clicked, with value:", submittedValue);
-          postSurvey({name: submittedValue})
+          postSurvey({ name: submittedValue })
         }
       }
       >
@@ -36,7 +38,7 @@ export default function CreateSurveyForm () {
       </button>
       <br />
       <br />
-      <Link to = "/"> Back to all surveys </Link>
+      <Link to="/"> Back to all surveys </Link>
 
     </div>
   )

--- a/app/routes/create.tsx
+++ b/app/routes/create.tsx
@@ -1,50 +1,43 @@
-import { expressPort, getSurveys } from "./_index";
+import { Link } from "@remix-run/react";
+import { expressPort } from "./_index";
 import { useState } from "react";
-
-const surveys = await getSurveys();
-
-console.log("From create.tsx, surveys looks like...", surveys)
 
 export const postSurvey = async ({ name }: NewSurvey) => {
   const response = await fetch (`http://localhost:${expressPort}/insert`, {
     method: "POST",
-    mode: "cors",
+    mode: "no-cors",
     cache: "no-cache",
-  }
-)
-
-console.log("response AAA is:", response)
-console.log(typeof response);
-
+    body: JSON.stringify(name)
+    }
+  )
+// full "response" is a massive sprawling object, .json() gives us the most salient part of it somehow
 const responseJson = await response.json()
-;
-console.log("response JSON is:", responseJson);
-
+console.log("postSurvey function called. Response received was:", response)
 }
-
 
 type NewSurvey = {
   name: string;
 }
 
-
 export default function CreateSurveyForm () {
   const [submittedValue, setSubmittedValue] = useState("")
+  console.log("submittedValue is:", submittedValue)
   return (
     <div>
-    <input type="text" value = {submittedValue} onChange={(e) => {setSubmittedValue(e.target.value)}}/>
-
-    <button type="submit" onClick={
-      ()=>{
-        console.log("Submit button has been clicked, with value:", submittedValue);
-        postSurvey({name: submittedValue})
+      <input type="text" value = {submittedValue} onChange={(e) => {setSubmittedValue(e.target.value)}}/>
+      <button type="submit" onClick={
+        ()=>{
+          console.log("Submit button has been clicked, with value:", submittedValue);
+          postSurvey({name: submittedValue})
+        }
       }
-    }
-    >
-      Submit
-    </button>
+      >
+        Submit
+      </button>
+      <br />
+      <br />
+      <Link to = "/"> Back to all surveys </Link>
 
-      
     </div>
   )
 }

--- a/app/routes/create.tsx
+++ b/app/routes/create.tsx
@@ -3,7 +3,7 @@ import type { ActionFunction, ActionFunctionArgs, LoaderFunctionArgs } from "@re
 import { Form, redirect, useActionData } from "@remix-run/react";
 import client from "~/client";
 
-import { getSurveys } from "./_index";
+import { expressPort, getSurveys } from "./_index";
 
 
 const surveys = await getSurveys();
@@ -11,23 +11,22 @@ const surveys = await getSurveys();
 console.log("From create.tsx, surveys looks like...", surveys)
 
 
-
 export const postSurvey = async ({ name }: NewSurvey) => {
-  const data = await fetch ("http://localhost:4000/",
-    
-    // {mode: "no-cors"}
-
-  )
-  // cross-resource origin sharing
-  // "when I'm a website, I should only be able to interact with other websites explicitly"
-  // CORS is a webscanner that prevents you from interacting with other websites
-  // in this case, it might be upset that I'm interacting with different websites
-
-  const surveys = (await data.json()) as {
-    surveys: Surveys
+  const response = await fetch (`http://localhost:${expressPort}/insert`, {
+    method: "POST",
+    mode: "cors",
+    cache: "no-cache",
   }
+)
 
-  return surveys
+console.log("response AAA is:", response)
+console.log(typeof response);
+
+const responseJson = await response.json()
+;
+// console.log("response JSON is:", responseJson);
+
+
 }
 
 
@@ -44,56 +43,29 @@ type NewSurvey = {
 
 
 
-export const action: ActionFunction = async ({ request }) => {
-  const data = await request.formData();
+// export const action: ActionFunction = async ({ request }) => {
+//   const data = await request.formData();
 
-  console.log("request.formData:", request.formData)
+//   console.log("request.formData:", request.formData)
 
-  const confirmedNewSurvey = await client.survey.create({ /// this function will return the doc item that is created
-    data: {
-      name: data.get("surveyName")?.toString() || "default survey name",
-      // name squiggly line if you don't have toString...because it otherwise returns a form data entry value type (specific to prisma)
-    }
-  })
+//   const confirmedNewSurvey = await client.survey.create({ /// this function will return the doc item that is created
+//     data: {
+//       name: data.get("surveyName")?.toString() || "default survey name",
+//       // name squiggly line if you don't have toString...because it otherwise returns a form data entry value type (specific to prisma)
+//     }
+//   })
 
-  return redirect(`/survey/${confirmedNewSurvey.id}`)
-}
+//   return redirect(`/survey/${confirmedNewSurvey.id}`)
+// }
 
 
 
 export default function CreateSurveyForm () {
-  const actionData = useActionData<typeof action>();
+  const actionData = null
   return (
     <div>
-      <Form method = "post" action="/create">
-  
-        <p>
-          <label>
-            Name: {" "}
-            <input 
-              name="surveyName" 
-              type="text"
-              placeholder="Enter your survey name here"
-            />
-          </label>
-        </p>
-
-        {actionData?.errors.name ? (
-          <p style = {{ color: "red "}}>
-            {actionData.errors.name}
-          </p>
-        ) : null }
-
-        <p>
-          <label>
-            Description: {" "}
-            <textarea name="description"></textarea>
-          </label>
-        </p>
-        <p>
-          <button type="submit">Create</button>
-        </p>
-      </Form>
+      <button onClick={() => postSurvey({name:"ha"})} > acjioew nemwoa</button>
+      
     </div>
   )
 }

--- a/app/routes/create.tsx
+++ b/app/routes/create.tsx
@@ -1,15 +1,9 @@
-
-import type { ActionFunction, ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
-import { Form, redirect, useActionData } from "@remix-run/react";
-import client from "~/client";
-
 import { expressPort, getSurveys } from "./_index";
-
+import { useState } from "react";
 
 const surveys = await getSurveys();
 
 console.log("From create.tsx, surveys looks like...", surveys)
-
 
 export const postSurvey = async ({ name }: NewSurvey) => {
   const response = await fetch (`http://localhost:${expressPort}/insert`, {
@@ -24,11 +18,9 @@ console.log(typeof response);
 
 const responseJson = await response.json()
 ;
-// console.log("response JSON is:", responseJson);
-
+console.log("response JSON is:", responseJson);
 
 }
-
 
 
 type NewSurvey = {
@@ -36,35 +28,22 @@ type NewSurvey = {
 }
 
 
-
-
-
-
-
-
-
-// export const action: ActionFunction = async ({ request }) => {
-//   const data = await request.formData();
-
-//   console.log("request.formData:", request.formData)
-
-//   const confirmedNewSurvey = await client.survey.create({ /// this function will return the doc item that is created
-//     data: {
-//       name: data.get("surveyName")?.toString() || "default survey name",
-//       // name squiggly line if you don't have toString...because it otherwise returns a form data entry value type (specific to prisma)
-//     }
-//   })
-
-//   return redirect(`/survey/${confirmedNewSurvey.id}`)
-// }
-
-
-
 export default function CreateSurveyForm () {
-  const actionData = null
+  const [submittedValue, setSubmittedValue] = useState("")
   return (
     <div>
-      <button onClick={() => postSurvey({name:"ha"})} > acjioew nemwoa</button>
+    <input type="text" value = {submittedValue} onChange={(e) => {setSubmittedValue(e.target.value)}}/>
+
+    <button type="submit" onClick={
+      ()=>{
+        console.log("Submit button has been clicked, with value:", submittedValue);
+        postSurvey({name: submittedValue})
+      }
+    }
+    >
+      Submit
+    </button>
+
       
     </div>
   )

--- a/app/routes/create.tsx
+++ b/app/routes/create.tsx
@@ -1,11 +1,47 @@
 
 import type { ActionFunction, ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
 import { Form, redirect, useActionData } from "@remix-run/react";
-import { json } from "@remix-run/react";
-import { useLoaderData } from "@remix-run/react";
 import client from "~/client";
 
-import { prismaDatabase } from "~/prismaDatabase";
+import { getSurveys } from "./_index";
+
+
+const surveys = await getSurveys();
+
+console.log("From create.tsx, surveys looks like...", surveys)
+
+
+
+export const postSurvey = async ({ name }: NewSurvey) => {
+  const data = await fetch ("http://localhost:4000/",
+    
+    // {mode: "no-cors"}
+
+  )
+  // cross-resource origin sharing
+  // "when I'm a website, I should only be able to interact with other websites explicitly"
+  // CORS is a webscanner that prevents you from interacting with other websites
+  // in this case, it might be upset that I'm interacting with different websites
+
+  const surveys = (await data.json()) as {
+    surveys: Surveys
+  }
+
+  return surveys
+}
+
+
+
+type NewSurvey = {
+  name: string;
+}
+
+
+
+
+
+
+
 
 
 export const action: ActionFunction = async ({ request }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@remix-run/react": "^2.9.2",
         "@remix-run/serve": "^2.9.2",
         "@types/express": "^4.17.21",
+        "axios": "^1.7.2",
         "express": "^4.19.2",
         "isbot": "^4.1.0",
         "react": "^18.2.0",
@@ -2761,6 +2762,11 @@
         "astring": "bin/astring"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2782,6 +2788,16 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
+      "dependencies": {
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -3250,6 +3266,17 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
@@ -3611,6 +3638,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -4933,6 +4968,25 @@
       "integrity": "sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
@@ -4967,6 +5021,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/format": {
@@ -8458,6 +8525,11 @@
       "engines": {
         "node": ">= 0.10"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/pump": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@remix-run/react": "^2.9.2",
     "@remix-run/serve": "^2.9.2",
     "@types/express": "^4.17.21",
+    "axios": "^1.7.2",
     "express": "^4.19.2",
     "isbot": "^4.1.0",
     "react": "^18.2.0",

--- a/server.ts
+++ b/server.ts
@@ -1,5 +1,6 @@
 import express, { RequestHandler } from "express";
 import client from "~/client";
+import { expressPort } from "~/routes/_index";
 
 const app = express();
 
@@ -23,8 +24,29 @@ app.get("/", async (req, res) => {
     res.json({ surveys });
 });
 
+app.post ("/insert", async(req, res) =>{
+    // I believe this this will be called by hitting localhost:4000/insert
+    const body = {
+        name: req.body.name
+    }
+
+    // if (!body.name) {
+    //     return res.status(400).json({
+    //         error: "survey name missing"
+    //     })
+    // }
+
+    console.log("The request to POST an entry has been received")
+
+    res.json("hi")
+
+    return(null)
+})
+
+
+
 // nothing happens until you set it to listen
 
-app.listen(4000, () => {
-    console.log("Server is running on port 4000")
+app.listen(expressPort, () => {
+    console.log("Server is running on port", expressPort)
 })

--- a/server.ts
+++ b/server.ts
@@ -24,11 +24,24 @@ app.get("/", async (req, res) => {
     res.json({ surveys });
 });
 
+
+
+
+
+
 app.post ("/insert", async(req, res) =>{
     // I believe this this will be called by hitting localhost:4000/insert
     const body = {
         name: req.body.name
     }
+
+    await client.survey.create({ /// this function will return the doc item that is created
+        data: {
+            name: body.name
+            // name: data.get("surveyName")?.toString() || "default survey name",
+            // name squiggly line if you don't have toString...because it otherwise returns a form data entry value type (specific to prisma)
+        }
+        })
 
     // if (!body.name) {
     //     return res.status(400).json({
@@ -42,6 +55,27 @@ app.post ("/insert", async(req, res) =>{
 
     return(null)
 })
+
+
+
+
+// FOR REFERENCE - THIS WAS HOW I GOT IT WORKING WITH ACTIONFUNCTION
+
+// export const action: ActionFunction = async ({ request }) => {
+//   const data = await request.formData();
+
+//   console.log("request.formData:", request.formData)
+
+//   const confirmedNewSurvey = await client.survey.create({ /// this function will return the doc item that is created
+//     data: {
+//       name: data.get("surveyName")?.toString() || "default survey name",
+//       // name squiggly line if you don't have toString...because it otherwise returns a form data entry value type (specific to prisma)
+//     }
+//   })
+
+//   return redirect(`/survey/${confirmedNewSurvey.id}`)
+// }
+
 
 
 

--- a/server.ts
+++ b/server.ts
@@ -26,9 +26,6 @@ app.get("/", async (req, res) => {
 
 
 
-
-
-
 app.post ("/insert", async(req, res) =>{
     // I believe this this will be called by hitting localhost:4000/insert
     const body = {
@@ -49,7 +46,7 @@ app.post ("/insert", async(req, res) =>{
     //     })
     // }
 
-    console.log("The request to POST an entry has been received")
+    console.log("The request to POST an entry has been received, with req as:", req)
 
     res.json("hi")
 
@@ -75,8 +72,6 @@ app.post ("/insert", async(req, res) =>{
 
 //   return redirect(`/survey/${confirmedNewSurvey.id}`)
 // }
-
-
 
 
 // nothing happens until you set it to listen

--- a/server.ts
+++ b/server.ts
@@ -2,14 +2,11 @@ import express, { RequestHandler } from "express";
 import client from "~/client";
 import { expressPort } from "~/routes/_index";
 
+console.log("####################### \n SERVER RESTARTED \n ####################### ")
+
 const app = express();
 
-// send a request request.body = '{"name": "John"}' -> {name: "John"}
-
-//bun.sh
 app.use(express.json());
-
-// cors
 
 app.use((req, res, next) => {
     res.setHeader("Access-Control-Allow-Origin", "*");
@@ -25,9 +22,9 @@ app.get("/", async (req, res) => {
 });
 
 
+// send a request request.body = '{"name": "John"}' -> {name: "John"}
 
-app.post ("/insert", async(req, res) =>{
-    // I believe this this will be called by hitting localhost:4000/insert
+app.post("/insert", async (req, res) => {
     const body = {
         name: req.body.name
     }
@@ -40,38 +37,15 @@ app.post ("/insert", async(req, res) =>{
         }
         })
 
-    // if (!body.name) {
-    //     return res.status(400).json({
-    //         error: "survey name missing"
-    //     })
-    // }
+    if (!body.name) {
+        return res.status(400).json({
+            error: "survey name missing"
+        })
+    }
 
-    console.log("The request to POST an entry has been received, with req as:", req)
-
-    res.json("hi")
-
-    return(null)
+    res.send(req.body)
+    // this has similarities with 'return'...so a return after this would not be called
 })
-
-
-
-
-// FOR REFERENCE - THIS WAS HOW I GOT IT WORKING WITH ACTIONFUNCTION
-
-// export const action: ActionFunction = async ({ request }) => {
-//   const data = await request.formData();
-
-//   console.log("request.formData:", request.formData)
-
-//   const confirmedNewSurvey = await client.survey.create({ /// this function will return the doc item that is created
-//     data: {
-//       name: data.get("surveyName")?.toString() || "default survey name",
-//       // name squiggly line if you don't have toString...because it otherwise returns a form data entry value type (specific to prisma)
-//     }
-//   })
-
-//   return redirect(`/survey/${confirmedNewSurvey.id}`)
-// }
 
 
 // nothing happens until you set it to listen


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



| :rocket: | This description was created by [Ellipsis](https://www.ellipsis.dev) for commit 8ca16eb520003a44b0bd385692e90b750932c856  | 
|--------|--------|

### Summary:
This PR transitions the survey creation functionality from Remix to an Express-based backend, enhancing the application's architecture and efficiency.

**Key points**:
- Moved survey creation from Remix to Express.
- Updated fetch URL to use variable `expressPort`.
- Added POST endpoint in Express to handle survey creation.
- Modified React component to send POST requests to the new Express endpoint.
- Updated `package.json` to include new dependencies like `axios`.
- Utilized `useState` in React for handling form state.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)


<!-- ELLIPSIS_HIDDEN -->